### PR TITLE
Filename string update 

### DIFF
--- a/internal/epub/core.go
+++ b/internal/epub/core.go
@@ -247,7 +247,7 @@ func (e *ePub) Write() error {
 		ext := filepath.Ext(e.Output)
 		suffix := ""
 		if totalParts > 1 {
-			suffix = fmt.Sprintf(" PART_%02d", i+1)
+			suffix = fmt.Sprintf(" [%d_%d]", i+1, totalParts)
 		}
 
 		path := fmt.Sprintf("%s%s%s", e.Output[0:len(e.Output)-len(ext)], suffix, ext)


### PR DESCRIPTION
Updated filename string to resemble the metadata
filename [1/3]
When sending book using the SendToKindle Service filename still says "PART_1" which doesn't tell us the total parts
SendToKindle doesn't seem to read the title from the metadata.
