### PR TITLE
Add profile for the reMarkable2 ePaper tablet

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,7 +449,7 @@ Config:
     	    - KoF     ( 1440x1920 ) - Kobo Forma
     	    - KoS     ( 1440x1920 ) - Kobo Sage
     	    - KoE     ( 1404x1872 ) - Kobo Elipsa
-			- RM      ( 1404x1872 ) - reMarkable 2
+    	    - RM      ( 1404x1872 ) - reMarkable 2
   -quality int (default 85)
     	Quality of the image
   -grayscale (default true)

--- a/README.md
+++ b/README.md
@@ -449,6 +449,7 @@ Config:
     	    - KoF     ( 1440x1920 ) - Kobo Forma
     	    - KoS     ( 1440x1920 ) - Kobo Sage
     	    - KoE     ( 1404x1872 ) - Kobo Elipsa
+			- RM      ( 1404x1872 ) - reMarkable 2
   -quality int (default 85)
     	Quality of the image
   -grayscale (default true)

--- a/internal/converter/profiles/converter_profiles.go
+++ b/internal/converter/profiles/converter_profiles.go
@@ -49,6 +49,7 @@ func New() Profiles {
 		{"KoF", "Kobo Forma", 1440, 1920},
 		{"KoS", "Kobo Sage", 1440, 1920},
 		{"KoE", "Kobo Elipsa", 1404, 1872},
+		{"RM2", "reMarkable 2", 1404, 1872},
 	}
 }
 

--- a/internal/converter/profiles/converter_profiles.go
+++ b/internal/converter/profiles/converter_profiles.go
@@ -49,6 +49,7 @@ func New() Profiles {
 		{"KoF", "Kobo Forma", 1440, 1920},
 		{"KoS", "Kobo Sage", 1440, 1920},
 		{"KoE", "Kobo Elipsa", 1404, 1872},
+		// reMarkable
 		{"RM2", "reMarkable 2", 1404, 1872},
 	}
 }


### PR DESCRIPTION
Tiny PR for the screen properties of the reMarkable tablet.

I've been happy so far using this to convert files for the tablet, and a default profile would be nice :)
