### PR TITLE
Add object-fit: contain to img css to preserve aspect ratio

### DIFF
--- a/internal/pkg/epubtemplates/style.css.tmpl
+++ b/internal/pkg/epubtemplates/style.css.tmpl
@@ -15,4 +15,5 @@ img {
   margin:0;
   padding:0;
   z-index:0;
+  object-fit: contain;
 }


### PR DESCRIPTION
Readers like Calibre and ttsu does not respect aspect ratio unless img object-fit in style.css is specified.
I added `object-fit: contain;` to keep the aspect radio and not crop the image.